### PR TITLE
Make the Site Prettier

### DIFF
--- a/.frogrc
+++ b/.frogrc
@@ -93,3 +93,13 @@ source-dir = src
 # to the project top directory, i.e. to where this .frogrc file is
 # located.
 output-dir = site
+
+# Options controlling Pygments' HTML format.
+## Python executable to be passed to the shell. If only a filename or
+## relative path is given, Racket's find-executable-path will be used
+## to locate the executable.
+python-executable = python
+## Whether to use line numbers.
+pygments-linenos? = #f
+## CSS class for the wrapping <div> tag (default: 'highlight').
+pygments-cssclass = source

--- a/site/css/codemirror.css
+++ b/site/css/codemirror.css
@@ -61,28 +61,15 @@
 
 /* DEFAULT THEME */
 
-.cm-s-default .cm-keyword {color: #708;}
-.cm-s-default .cm-atom {color: #219;}
-.cm-s-default .cm-number {color: #164;}
-.cm-s-default .cm-def {color: #00f;}
-.cm-s-default .cm-variable {color: black;}
-.cm-s-default .cm-variable-2 {color: #05a;}
-.cm-s-default .cm-variable-3 {color: #085;}
-.cm-s-default .cm-property {color: black;}
-.cm-s-default .cm-operator {color: black;}
-.cm-s-default .cm-comment {color: #a50;}
-.cm-s-default .cm-string {color: #a11;}
-.cm-s-default .cm-string-2 {color: #f50;}
-.cm-s-default .cm-meta {color: #555;}
-.cm-s-default .cm-qualifier {color: #555;}
-.cm-s-default .cm-builtin {color: #30a;}
-.cm-s-default .cm-bracket {color: #997;}
-.cm-s-default .cm-tag {color: #170;}
-.cm-s-default .cm-attribute {color: #00c;}
-.cm-s-default .cm-header {color: blue;}
-.cm-s-default .cm-quote {color: #090;}
-.cm-s-default .cm-hr {color: #999;}
-.cm-s-default .cm-link {color: #00c;}
+.cm-s-default.CodeMirror { color: #111; }
+.cm-s-default .cm-comment { color: #39f; }
+.cm-s-default .cm-builtin { color: #555; }
+.cm-s-default .cm-function-name { color: #111; }
+.cm-s-default .cm-variable { color: #111; }
+.cm-s-default .cm-keyword { color: #708; }
+.cm-s-default .cm-number { color: #164; }
+.cm-s-default .cm-string { color: #164; }
+.cm-s-default .cm-type { color: #111; }
 
 .cm-negative {color: #d44;}
 .cm-positive {color: #292;}

--- a/site/css/custom.css
+++ b/site/css/custom.css
@@ -21,6 +21,13 @@ pre {
   background-color: #eee;
   border: 0px;
   margin-bottom: 0px;
+  width: 100%;
+  position: fixed;
+}
+
+.jumbotron {
+  /* 48px from Bootstrap + 66px from Navbar (30px padding + 36px image)*/
+  padding-top: 114px;
 }
 
 img.navbar-logo {

--- a/site/css/custom.css
+++ b/site/css/custom.css
@@ -14,6 +14,7 @@ code {
 pre {
   white-space: pre;
   font-family: 'Hack', monospace;
+  overflow-x: auto;
 }
 
 .navbar {

--- a/site/css/custom.css
+++ b/site/css/custom.css
@@ -150,6 +150,7 @@ img.title-logo {
 }
 
 .hvr-border-fade {
+  line-height: inherit;
   display: inline-block;
   vertical-align: middle;
   -webkit-transform: translateZ(0);

--- a/site/css/custom.css
+++ b/site/css/custom.css
@@ -1,7 +1,11 @@
 /* custom.css */
 
+a:active, a:focus {
+  outline: 0;
+}
+
 code {
-    color: black;
+  color: black;
 }
 
 /* When highlighted code blocks are too wide, they wrap. Resulting in the */
@@ -178,6 +182,10 @@ h1 {
 div.carousel {
   height : 100%;
   min-height : 100%;
+}
+
+a.carousel-control {
+  text-shadow: none;
 }
 
 a.carousel-control.right {

--- a/site/css/custom.css
+++ b/site/css/custom.css
@@ -9,11 +9,13 @@ code {
 /* wrapping. */
 pre {
   white-space: pre;
-  font-family: Consolas, monospace;
+  font-family: 'Hack', monospace;
 }
 
 .navbar {
   background-color: #eee;
+  border: 0px;
+  margin-bottom: 0px;
 }
 
 img.navbar-logo {
@@ -32,6 +34,129 @@ img.title-logo {
 
 .navbar-nav>li>a {
   color: #111 !important;
+}
+
+/* Credit to Ian Lunn for Hovering CSS3 Code */
+
+.fancyhover-above,
+.fancyhover-below {
+  display: inline-block;
+  vertical-align: middle;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -moz-osx-font-smoothing: grayscale;
+  position: relative;
+  overflow: hidden;
+}
+.fancyhover-above:before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  left: 0;
+  right: 0;
+  top: 0;
+  background: #0c46ff;
+  height: 4px;
+  -webkit-transform: translateY(-4px);
+  transform: translateY(-4px);
+  -webkit-transition-property: transform;
+  transition-property: transform;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease-out;
+  transition-timing-function: ease-out;
+}
+
+.fancyhover-above:hover:before,
+.fancyhover-above:focus:before,
+.fancyhover-above:active:before,
+.fancyhover-below:hover:before,
+.fancyhover-below:focus:before,
+.fancyhover-below:active:before {
+  -webkit-transform: translateY(0);
+  transform: translateY(0);
+}
+
+.fancyhover-below {
+  display: inline-block;
+  vertical-align: middle;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -moz-osx-font-smoothing: grayscale;
+  position: relative;
+  overflow: hidden;
+}
+
+.fancyhover-above:before,
+.fancyhover-below:before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  left: 0;
+  right: 0;
+  background: #0c46ff;
+  height: 4px;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-timing-function: ease-out;
+  transition-timing-function: ease-out;
+}
+
+.fancyhover-above:before {
+  top: 0;
+  -webkit-transform: translateY(-4px);
+  transform: translateY(-4px);
+}
+
+.fancyhover-below:before {
+  bottom: 0;
+  -webkit-transform: translateY(4px);
+  transform: translateY(4px);
+}
+
+.btn-primary {
+  color: #444;
+  background-color: transparent;
+  border-color: transparent;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active {
+  background-color: transparent;
+  border-color:transparent;
+  color: inherit;
+}
+
+.hvr-border-fade {
+  display: inline-block;
+  vertical-align: middle;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0);
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: box-shadow, color;
+  transition-property: box-shadow, color;
+  box-shadow: inset 0 0 0 2px #888, 0 0 1px rgba(0, 0, 0, 0);
+  /* Hack to improve aliasing on mobile/tablet devices */
+}
+.hvr-border-fade:hover, .hvr-border-fade:focus, .hvr-border-fade:active {
+  box-shadow: inset 0 0 0 2px #ee1e10, 0 0 1px rgba(0, 0, 0, 0);
+  /* Hack to improve aliasing on mobile/tablet devices */
+  color: #ee1e10;
 }
 
 .popover-title {
@@ -85,17 +210,26 @@ div.carousel-inner pre {
 
 }
 
+.jumbotron p {
+  font-family : 'Merriweather';
+  font-weight: 300;
+  font-size: 14pt;
+}
+
 #content p {
-  font-family : Georgia;
+  font-family : 'Merriweather';
+  font-weight: 300;
   font-size : 14pt;
 }
 
 #content ul {
-  font-family : Georgia;
+  font-family : 'Merriweather';
+  font-weight: 300;
   font-size : 14pt;
 }
 
 #content ol {
-  font-family : Georgia;
+  font-family : 'Merriweather';
+  font-weight: 300;
   font-size : 14pt;
 }

--- a/site/css/custom.css
+++ b/site/css/custom.css
@@ -1,5 +1,9 @@
 /* custom.css */
 
+body > div:first-of-type {
+  padding-top: 66px;
+}
+
 a:active, a:focus {
   outline: 0;
 }
@@ -27,7 +31,7 @@ pre {
 
 .jumbotron {
   /* 48px from Bootstrap + 66px from Navbar (30px padding + 36px image)*/
-  padding-top: 114px;
+  padding-top: 114px !important;
 }
 
 img.navbar-logo {

--- a/site/css/pygments.css
+++ b/site/css/pygments.css
@@ -1,60 +1,61 @@
+/* NOTE: This file is not fully in sync with `codemirror.css`. Update as needed. */
 .hll { background-color: #ffffcc }
-.c { color: #999988; font-style: italic } /* Comment */
+.c { color: #39f } /* Comment */
 .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.k { color: #000000; font-weight: bold } /* Keyword */
-.o { color: #000000; font-weight: bold } /* Operator */
-.cm { color: #999988; font-style: italic } /* Comment.Multiline */
+.k { color: #708 } /* Keyword */
+.o { color: #000000 } /* Operator */
+.cm { color: #39f } /* Comment.Multiline */
 .cp { color: #999999; font-weight: bold; font-style: italic } /* Comment.Preproc */
-.c1 { color: #999988; font-style: italic } /* Comment.Single */
+.c1 { color: #39f } /* Comment.Single */
 .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
 .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
 .ge { color: #000000; font-style: italic } /* Generic.Emph */
 .gr { color: #aa0000 } /* Generic.Error */
 .gh { color: #999999 } /* Generic.Heading */
-.gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.gi { color: #000000 } /* Generic.Inserted */
 .go { color: #888888 } /* Generic.Output */
 .gp { color: #555555 } /* Generic.Prompt */
 .gs { font-weight: bold } /* Generic.Strong */
 .gu { color: #aaaaaa } /* Generic.Subheading */
 .gt { color: #aa0000 } /* Generic.Traceback */
-.kc { color: #000000; font-weight: bold } /* Keyword.Constant */
-.kd { color: #000000; font-weight: bold } /* Keyword.Declaration */
-.kn { color: #000000; font-weight: bold } /* Keyword.Namespace */
-.kp { color: #000000; font-weight: bold } /* Keyword.Pseudo */
-.kr { color: #000000; font-weight: bold } /* Keyword.Reserved */
-.kt { color: #445588; font-weight: bold } /* Keyword.Type */
+.kc { color: #000000 } /* Keyword.Constant */
+.kd { color: #708 } /* Keyword.Declaration */
+.kn { color: #708 } /* Keyword.Namespace */
+.kp { color: #000000 } /* Keyword.Pseudo */
+.kr { color: #000000 } /* Keyword.Reserved */
+.kt { color: #111 } /* Keyword.Type */
 .m { color: #009999 } /* Literal.Number */
 .s { color: #d01040 } /* Literal.String */
-.na { color: #008080 } /* Name.Attribute */
-.nb { color: #0086B3 } /* Name.Builtin */
-.nc { color: #445588; font-weight: bold } /* Name.Class */
-.no { color: #008080 } /* Name.Constant */
-.nd { color: #3c5d5d; font-weight: bold } /* Name.Decorator */
-.ni { color: #800080 } /* Name.Entity */
-.ne { color: #990000; font-weight: bold } /* Name.Exception */
-.nf { color: #990000; font-weight: bold } /* Name.Function */
-.nl { color: #990000; font-weight: bold } /* Name.Label */
-.nn { color: #555555 } /* Name.Namespace */
-.nt { color: #000080 } /* Name.Tag */
-.nv { color: #008080 } /* Name.Variable */
-.ow { color: #000000; font-weight: bold } /* Operator.Word */
+.na { color: #111 } /* Name.Attribute */
+.nb { color: #111 } /* Name.Builtin */
+.nc { color: #111 } /* Name.Class */
+.no { color: #111 } /* Name.Constant */
+.nd { color: #111 } /* Name.Decorator */
+.ni { color: #111 } /* Name.Entity */
+.ne { color: #111 } /* Name.Exception */
+.nf { color: #111 } /* Name.Function */
+.nl { color: #111 } /* Name.Label */
+.nn { color: #111 } /* Name.Namespace */
+.nt { color: #111 } /* Name.Tag */
+.nv { color: #111 } /* Name.Variable */
+.ow { color: #000000 } /* Operator.Word */
 .w { color: #bbbbbb } /* Text.Whitespace */
-.mf { color: #009999 } /* Literal.Number.Float */
-.mh { color: #009999 } /* Literal.Number.Hex */
-.mi { color: #009999 } /* Literal.Number.Integer */
-.mo { color: #009999 } /* Literal.Number.Oct */
-.sb { color: #d01040 } /* Literal.String.Backtick */
-.sc { color: #d01040 } /* Literal.String.Char */
-.sd { color: #d01040 } /* Literal.String.Doc */
-.s2 { color: #d01040 } /* Literal.String.Double */
-.se { color: #d01040 } /* Literal.String.Escape */
-.sh { color: #d01040 } /* Literal.String.Heredoc */
-.si { color: #d01040 } /* Literal.String.Interpol */
-.sx { color: #d01040 } /* Literal.String.Other */
-.sr { color: #009926 } /* Literal.String.Regex */
-.s1 { color: #d01040 } /* Literal.String.Single */
-.ss { color: #990073 } /* Literal.String.Symbol */
-.bp { color: #999999 } /* Name.Builtin.Pseudo */
+.mf { color: #164 } /* Literal.Number.Float */
+.mh { color: #164 } /* Literal.Number.Hex */
+.mi { color: #164 } /* Literal.Number.Integer */
+.mo { color: #164 } /* Literal.Number.Oct */
+.sb { color: #164 } /* Literal.String.Backtick */
+.sc { color: #164 } /* Literal.String.Char */
+.sd { color: #164 } /* Literal.String.Doc */
+.s2 { color: #164 } /* Literal.String.Double */
+.se { color: #164 } /* Literal.String.Escape */
+.sh { color: #164 } /* Literal.String.Heredoc */
+.si { color: #164 } /* Literal.String.Interpol */
+.sx { color: #164 } /* Literal.String.Other */
+.sr { color: #164 } /* Literal.String.Regex */
+.s1 { color: #164 } /* Literal.String.Single */
+.ss { color: #164 } /* Literal.String.Symbol */
+.bp { color: #000000 } /* Name.Builtin.Pseudo */
 .vc { color: #008080 } /* Name.Variable.Class */
 .vg { color: #008080 } /* Name.Variable.Global */
 .vi { color: #008080 } /* Name.Variable.Instance */

--- a/src/page-template.html
+++ b/src/page-template.html
@@ -14,6 +14,8 @@
     <link rel="icon"      href="/img/pyret-icon.png">
     <link rel="canonical" href="@|full-uri|">
     <!-- CSS -->
+    <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/font-hack/2.019/css/hack.min.css">
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/pygments.css">
     <link rel="stylesheet" type="text/css" href="/css/codemirror.css">
@@ -56,86 +58,26 @@ s.parentNode.insertBefore(ga, s);
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a href="/index.html" class="navbar-brand">
+          <a href="/index.html" class="navbar-brand fancyhover-above">
             <img class="navbar-logo" src="/img/pyret-banner.png"></img>
           </a>
         </div>
         <div class="collapse navbar-collapse our-nav-collapse"
              role="navigation">
           <ul class="nav navbar-nav">
-            <li><a href="/#examples">Examples</a></li>
-            <li><a target="_blank" href="https://code.pyret.org">Set Sail</a></li>
-            <li><a href="/discuss/">News &amp; Discussion</a></li>
-            <li><a href="/docs/latest/">Documentation</a></li>
-            <li><a href="https://github.com/brownplt/pyret-lang">Code</a></li>
-            <li><a href="/crew/">Crew</a></li>
+            <li><a class="fancyhover-above" href="/#examples">Examples</a></li>
+            <li><a class="fancyhover-above" target="_blank" href="https://code.pyret.org">Set Sail</a></li>
+            <li><a class="fancyhover-above" href="/discuss/">News &amp; Discussion</a></li>
+            <li><a class="fancyhover-above" href="/docs/latest/">Documentation</a></li>
+            <li><a class="fancyhover-above" href="https://github.com/brownplt/pyret-lang">Code</a></li>
+            <li><a class="fancyhover-above" href="/crew/">Crew</a></li>
           </ul>
         </div>
     </header>
-    <div class="container">
-      <div class="row">
-        @;{ Remember that Twitter Bootstrap has a 12 cell model. The
-            col-md-N classes should add up to 12.  For instance 3
-            "col-md-4" divs, or 2 "col-md-6" divs. }
-        <!-- Main column -->
-        <div id="content" class="col-md-12">
-@(when (string-ci=? uri-path "/index.html")
-  @(define (info-code code info)
-    @disable-prefix{<span class="info" title="@|info|">@|code|</span>})
-
-  @(define (two-langs header words other-lang pyret-code other-code)
-    (define other-block
-      @list{
-      <div class="col-md-4"><b>@|other-lang|</b><pre class="non-pyret">@|other-code|</pre> </div>
-      })
-    (define pyret-block
-      @list{
-      <div class="col-md-4"><b>Pyret</b><pre>@|pyret-code|</pre> </div>
-      })
-    (define description-block
-      @list{
-      <div class="col-md-4"><b>@|header|</b><p>@|words|</p></div>
-      })
+    @(when (string-ci=? uri-path "/index.html")
     @list{
-      <div class="row">
-        @description-block
-        @other-block
-        @pyret-block
-      </div>
-    })
-
-  @(define (pyret-example code description #:where (where 'left))
-    (define code-block
-      @list{
-      <div class="col-md-6"> <pre>@|code|</pre> </div>
-      })
-    (define description-block @list{
-      <div class="col-md-4">
-      <p>@|description|</p>
-      </div>
-    })
-    (cond
-      [(equal? where 'left) @list{
-          <div class="row">
-            <div class="col-md-1"></div>
-        @|code-block|
-        @|description-block|
-            <div class="col-md-1"></div>
-          </div>
-            }]
-            [(equal? where 'right) @list{
-          <div class="row">
-            <div class="col-md-1"></div>
-        @|description-block|
-        @|code-block|
-            <div class="col-md-1"></div>
-          </div>
-        }]))
-
-
-@list{
-<div class="jumbotron">
-  <div class="container">
+    <div class="jumbotron">
+      <div class="container">
     <div class="row">
       <div class="col-md-6">
       <img class="title-logo" src="/img/pyret-banner.png"></img>
@@ -146,10 +88,10 @@ s.parentNode.insertBefore(ga, s);
       development, and free to use or modify.
       </p>
       <p>
-        <a href="/#examples" class="btn btn-primary btn-m">Examples</a>
-        <a target="_blank" href="https://code.pyret.org" class="btn btn-primary btn-m">Set Sail</a>
-        <a href="/discuss/" class="btn btn-primary btn-m">News &amp; Discussion</a>
-        <a href="https://github.com/brownplt/pyret-lang" class="btn btn-primary btn-m">Code</a>
+        <a href="/#examples" class="btn btn-primary btn-m hvr-border-fade">Examples</a>
+        <a target="_blank" href="https://code.pyret.org" class="btn btn-primary btn-m hvr-border-fade">Set Sail</a>
+        <a href="/discuss/" class="btn btn-primary btn-m hvr-border-fade">News &amp; Discussion</a>
+        <a href="https://github.com/brownplt/pyret-lang" class="btn btn-primary btn-m hvr-border-fade">Code</a>
       </p>
       </div>
       <div class="col-md-6">
@@ -279,7 +221,71 @@ end
       </div>
     </div>
   </div>
-</div>
+    </div>
+    })
+    <div class="container">
+      <div class="row">
+        @;{ Remember that Twitter Bootstrap has a 12 cell model. The
+            col-md-N classes should add up to 12.  For instance 3
+            "col-md-4" divs, or 2 "col-md-6" divs. }
+        <!-- Main column -->
+        <div id="content" class="col-md-12">
+@(when (string-ci=? uri-path "/index.html")
+  @(define (info-code code info)
+    @disable-prefix{<span class="info" title="@|info|">@|code|</span>})
+
+  @(define (two-langs header words other-lang pyret-code other-code)
+    (define other-block
+      @list{
+      <div class="col-md-4"><b>@|other-lang|</b><pre class="non-pyret">@|other-code|</pre> </div>
+      })
+    (define pyret-block
+      @list{
+      <div class="col-md-4"><b>Pyret</b><pre>@|pyret-code|</pre> </div>
+      })
+    (define description-block
+      @list{
+      <div class="col-md-4"><b>@|header|</b><p>@|words|</p></div>
+      })
+    @list{
+      <div class="row">
+        @description-block
+        @other-block
+        @pyret-block
+      </div>
+    })
+
+  @(define (pyret-example code description #:where (where 'left))
+    (define code-block
+      @list{
+      <div class="col-md-6"> <pre>@|code|</pre> </div>
+      })
+    (define description-block @list{
+      <div class="col-md-4">
+      <p>@|description|</p>
+      </div>
+    })
+    (cond
+      [(equal? where 'left) @list{
+          <div class="row">
+            <div class="col-md-1"></div>
+        @|code-block|
+        @|description-block|
+            <div class="col-md-1"></div>
+          </div>
+            }]
+            [(equal? where 'right) @list{
+          <div class="row">
+            <div class="col-md-1"></div>
+        @|description-block|
+        @|code-block|
+            <div class="col-md-1"></div>
+          </div>
+        }]))
+
+
+@list{
+
 
 <a name="examples"></a>
 <h2>Programming in Pyret</h2>

--- a/src/page-template.html
+++ b/src/page-template.html
@@ -1,4 +1,20 @@
 @(define disable-prefix (dynamic-require 'scribble/text 'disable-prefix))
+@(define pygmentize/raw   (dynamic-require 'frog/pygments 'pygmentize))
+@(define xexpr->string (dynamic-require 'xml 'xexpr->string))
+@(define current-pygments-linenos? (dynamic-require 'frog/params 'current-pygments-linenos?))
+@(define (sanitize-pygments-output o)
+  (define (remove-trailing-newline lst)
+    (cond [(null? lst) lst]
+          [(and (null? (cdr lst)) (equal? (car lst) "\n")) '()]
+          [(and (null? (cdr lst)) (pair? (car lst))) (list (remove-trailing-newline (car lst)))]
+          [else (cons (car lst) (remove-trailing-newline (cdr lst)))]))
+  `((div ((class "source")) (pre ((class "non-pyret"))
+    ,@(remove-trailing-newline (cddr (caddar o)))))))
+@(define (pygmentize lang . code)
+   (parameterize ([current-pygments-linenos? #f]
+                  [current-output-port (open-output-string)])
+    (let ([res (sanitize-pygments-output (pygmentize/raw (apply string-append code) lang))])
+      (xexpr->string `(div ([class ,(string-append "brush: " lang)]) ,@res)))))
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -235,10 +251,10 @@ end
     @disable-prefix{<span class="info" title="@|info|">@|code|</span>})
 
   @(define (two-langs header words other-lang pyret-code other-code)
-    (define other-block
-      @list{
-      <div class="col-md-4"><b>@|other-lang|</b><pre class="non-pyret">@|other-code|</pre> </div>
-      })
+     (define other-block
+         @list{
+         <div class="col-md-4"><b>@|other-lang|</b>@disable-prefix[other-code]</div>
+         })
     (define pyret-block
       @list{
       <div class="col-md-4"><b>Pyret</b><pre>@|pyret-code|</pre> </div>
@@ -466,7 +482,7 @@ fun square(n :: Number) -> Number:
   n * n
 end
 }
-@disable-prefix{
+@pygmentize["python"]{
 def square(n):
   return n * n
 }
@@ -481,7 +497,7 @@ languages do."
 fun square(n) -> Number:
   n * n
 end}
-@disable-prefix{
+@pygmentize["java"]{
 static int square(int n) @"{"
   return n * n;
 @"}"})
@@ -496,7 +512,7 @@ fun insert(e :: Number,
     -> BST % (is-balanced):
   # self-balancing tree insertion
 end}
-@disable-prefix{
+@pygmentize["python"]{
 def insert(e, s):
   # tree insertion but with
   # invariants neither
@@ -511,7 +527,7 @@ students to using just 32 bits."
 # this is true
 ((1 / 3) * 3) == 1
 }
-@disable-prefix{
+@pygmentize["java"]{
 // this is not true
 ((1 / 3) * 3) == 1
 })
@@ -529,7 +545,7 @@ check:
   [list: 2,4,6,8].first is 2
 end
 }
-@disable-prefix{
+@pygmentize["python"]{
 import unittest
 class TestLists(unittest.TestCase):
   def test_empty_first(self):
@@ -569,7 +585,7 @@ data BinTree:
   | leaf
   | node(v, l, r)
 end}
-@disable-prefix{
+@pygmentize["python"]{
 class BinTree:
   pass
 class leaf(BinTree):
@@ -605,7 +621,7 @@ fun animal-name(a :: Animal):
   a.name
 end
 }
-@disable-prefix{
+@pygmentize["ocaml"]{
 type animal =
   | Elephant of string * float
   | Tiger of string * float
@@ -634,7 +650,7 @@ fun animal-name(a :: Animal):
   a.name
 end
 }
-@disable-prefix{
+@pygmentize["racket"]{
 (struct elephant (name weight))
 (struct tiger (name stripes))
 (struct horse (name races-won))
@@ -670,7 +686,7 @@ check:
   method-as-fun(5) is 15
 end
 }
-@disable-prefix{
+@pygmentize["javascript"]{
 var o = @"{"
   my_method: function(x) @"{"
     return this.y + x;
@@ -697,7 +713,7 @@ check:
   method-as-fun(5) is 15
 end
 }
-@disable-prefix{
+@pygmentize["ruby"]{
 o = Object.new
 def o.my_method(x)
   self.y + x


### PR DESCRIPTION
This PR makes a couple of tweaks to make the Pyret website less 'standard-bootstrap'-y. I tried playing with the color scheme, but, with the colors in the main logo, grey really seems to be the best option.

A demo of the site with the changes can be found [here](http://belph.github.io/pyret-hip/).