### PR TITLE
Add missing Garamond font

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -4,6 +4,8 @@
   /* from code.pyret.org */
   --pyret-run-blue: #317bcf;
   --pyret-stop-red: #CF3B31;
+
+  --pyret-serif: 'EB Garamond', 'Adobe Garamond Pro', serif;
 }
 
 body > div:first-of-type {
@@ -335,7 +337,7 @@ li.hidden-pill {
 }
 
 #examplesTabsContent p {
-  font-family: "Garamond";
+  font-family: var(--pyret-serif);
   font-size: 12pt;
 }
 
@@ -347,7 +349,7 @@ li.hidden-pill {
 }
 
 .jumbotron p {
-  font-family: 'Garamond';
+  font-family: var(--pyret-serif);
   font-size: 14pt;
 }
 
@@ -384,7 +386,7 @@ button.runnable-pyret {
 }
 
 .feature p {
-  font-family: 'Garamond';
+  font-family: var(--pyret-serif);
   font-size: 14pt;
 }
 

--- a/template.html.pp
+++ b/template.html.pp
@@ -20,7 +20,6 @@
     <meta name="viewport"    content="width=device-width, initial-scale=1.0">
     <link rel="icon"      href="./img/pyret-icon.png">
     <link rel="canonical" href="@|full-uri|">
-    <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&display=swap">
     <link rel="stylesheet" href="//cdn.jsdelivr.net/font-hack/2.019/css/hack.min.css">
     <link rel="stylesheet" type="text/css" href="./bootstrap-css/bootstrap-5.0.2-dist/css/bootstrap.min.css">

--- a/template.html.pp
+++ b/template.html.pp
@@ -21,6 +21,7 @@
     <link rel="icon"      href="./img/pyret-icon.png">
     <link rel="canonical" href="@|full-uri|">
     <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&display=swap">
     <link rel="stylesheet" href="//cdn.jsdelivr.net/font-hack/2.019/css/hack.min.css">
     <link rel="stylesheet" type="text/css" href="./bootstrap-css/bootstrap-5.0.2-dist/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="./css/pygments.css">


### PR DESCRIPTION
Right now, the serif font on the homepage is the default browser serif font for users who do not have Garamond installed.

This PR hotlinks [EB Garamond](https://fonts.google.com/specimen/EB+Garamond) from Google Fonts, removes an unused hotlink to Merriweather, and updates the CSS to use EB Garamond with a fallback to the similar Adobe Garamond Pro (bundled with macOS) and the default browser serif font.

| Before                                                                               | After                                                                                |
|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
| ![](https://github.com/user-attachments/assets/b7b84ce3-79db-4734-8daf-e363f3639b84) | ![](https://github.com/user-attachments/assets/0871ecda-cafa-4f48-a2dc-68dd3b995138) |

I didn't update [`site/css/custom.css`](https://github.com/brownplt/pyret.org/blob/7cb6a51d55635da2b2baa3d6c0f01e7940e84724/site/css/custom.css) and [`src/page-template.html`](https://github.com/brownplt/pyret.org/blob/7cb6a51d55635da2b2baa3d6c0f01e7940e84724/src/page-template.html#L33), which don't appear to be used anymore but still reference Merriweather and Garamond respectively.